### PR TITLE
add initial CORS middleware

### DIFF
--- a/internal/middleware/cors_mw.go
+++ b/internal/middleware/cors_mw.go
@@ -1,0 +1,27 @@
+package middleware
+
+import "github.com/gin-gonic/gin"
+
+func CORSMiddleware() gin.HandlerFunc {
+	allowedOrigins := map[string]bool{
+		"http://localhost:5173": true, // TODO: get in db later
+	}
+
+	return func(c *gin.Context) {
+		origin := c.Request.Header.Get("Origin")
+
+		if allowedOrigins[origin] {
+			c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
+		}
+
+		c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+
+		if c.Request.Method == "OPTIONS" {
+			c.AbortWithStatus(204)
+			return
+		}
+		c.Next()
+	}
+}


### PR DESCRIPTION
This pull request adds a new middleware for handling CORS (Cross-Origin Resource Sharing) requests in the application. The middleware restricts allowed origins and sets necessary headers to support cross-origin requests.

CORS middleware implementation:

* Added a new file `internal/middleware/cors_mw.go` containing the `CORSMiddleware` function, which checks the request origin against a whitelist and sets CORS headers accordingly.
* The middleware currently allows requests from `http://localhost:5173` and handles preflight OPTIONS requests by aborting with a 204 status.