### PR TITLE
add initializer of other repositories for handlers

### DIFF
--- a/internal/initializers/handlers.go
+++ b/internal/initializers/handlers.go
@@ -7,21 +7,43 @@ import (
 )
 
 type HandlerContainer struct {
-	AuthHandler *v1.AuthHandler
+	AuthHandler   *v1.AuthHandler
+	ClientHandler *v1.ClientHandler
+	RoleHandler   *v1.RoleHandler
+	UserHandler   *v1.UserHandler
 }
 
 func InitializeHandlers(db *sqlx.DB) *HandlerContainer {
 	// Initialize Repositories
 	authRepo := repository.NewAuthCodeRepository(db)
+	sessionRepo := repository.NewSessionRepository(db)
+	clientRepo := repository.NewClientRepository(db)
+	roleRepo := repository.NewRoleRepository(db)
+	userRepo := repository.NewUserRepository(db)
 
 	// Create Handlers
 	authHandler := &v1.AuthHandler{
-		Repo:       authRepo,
+		Repo:        authRepo,
+		SessionRepo: sessionRepo,
+		PrivateKey:  PrivKey,
+	}
+	clientHandler := &v1.ClientHandler{
+		Repo: clientRepo,
 		PrivateKey: PrivKey,
 	}
+	roleHandler := &v1.RoleHandler{
+		Repo: roleRepo,
+	}
+	userHandler := &v1.UserHandler{
+		Repo: userRepo,
+	}
+
 
 	// Return Handlers
 	return &HandlerContainer{
 		AuthHandler: authHandler,
+		ClientHandler: clientHandler,
+		RoleHandler: roleHandler,
+		UserHandler: userHandler,
 	}
 }


### PR DESCRIPTION
This pull request adds new handler initializations to the `HandlerContainer` in `internal/initializers/handlers.go`, expanding support for client, role, and user operations. The changes also update the handler initialization logic to include new repositories and dependencies.

Handler initialization enhancements:

* Added `ClientHandler`, `RoleHandler`, and `UserHandler` fields to the `HandlerContainer` struct to support new handler types.
* Initialized corresponding repositories (`SessionRepository`, `ClientRepository`, `RoleRepository`, `UserRepository`) and passed them to their respective handlers.
* Updated `AuthHandler` initialization to include `SessionRepo` for improved session management.

Handler construction and return logic:

* Constructed new handler instances for client, role, and user, and included them in the returned `HandlerContainer`.